### PR TITLE
doc: Fix formatting of examples headers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ jobs:
         status: "${{ job.status }}"
 ```
 
-### Action with custom hold comments
+### Action with custom hold comments
 
 ```
 name: Test
@@ -200,7 +200,7 @@ jobs:
         failComment: "action failed!"
 ```
  
-### Action no comments, set commit to "error" status and set url, description and specific name
+### Action no comments, set commit to "error" status and set url, description and specific name
 
 ```
 name: Test


### PR DESCRIPTION
This commit ensures all example subsection headers are properly
rendered by GitHub replacing non-breaking spaces (ascii code 160)
with regular spaces (ascii code 32).


| Before | After |
|--|--|
| ![image](https://user-images.githubusercontent.com/219043/152634688-c6ca0ce2-97f4-4c56-b59d-c3ac1517436b.png) | ![image](https://user-images.githubusercontent.com/219043/152634779-bc95b3f7-d718-47e4-b12f-fd10d4b23b29.png) |


