### PR TITLE
doc: Fix example associating "name" with commit-status-updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: ouzi-dev/commit-status-updater@v1.1.0
       with:
         name: "name of my status check"
-    - uses: ouzi-dev/commit-status-updater@v1.1.0
 ```
 
 ### Action sets push commit to pending status on start, and updates check at the end of the workflow


### PR DESCRIPTION
This commit fixes the following warning reported when using the syntax originally suggested
in the second example "Action sets push commit to pending status with custom name":

```
  Unexpected input(s) 'name', valid inputs are ['repository', 'ref', 'token', 'ssh-key', 'ssh-known-hosts', 'ssh-strict', 'persist-credentials', 'path', 'clean', 'fetch-depth', 'lfs', 'submodules']
```